### PR TITLE
clang fixes

### DIFF
--- a/include/margs/arg_value.hpp
+++ b/include/margs/arg_value.hpp
@@ -80,7 +80,7 @@ namespace margs {
 	public:
 		constexpr arg_value() : _type(_value_type::null) {}
 		constexpr arg_value(const arg_value& value) : _type(value._type), _value(value._value) {}
-		constexpr arg_value(const std::string& value) : _type(_value_type::scalar), 
+		arg_value(const std::string& value) : _type(_value_type::scalar), 
 			_value(std::make_shared<std::string>(value)) {}
 		arg_value(const _vector_type& values) : _type(_value_type::sequence) {
 			_vector_ptr curr_value = std::make_shared<_vector_type>();

--- a/include/margs/basic_args_builder.hpp
+++ b/include/margs/basic_args_builder.hpp
@@ -74,11 +74,11 @@ namespace margs {
 			callback(values.at(Is).as<Ts>()...);
 		}
 		
-		static constexpr arg_callback_t _make_lambda(const _flag_callback_t& callback) {
+		static arg_callback_t _make_lambda(const _flag_callback_t& callback) {
 			return [callback](const arg_value&) -> void { callback(); };
 		}
 		template<class T, class... Ts>
-		static constexpr arg_callback_t _make_lambda(const _values_callback_t<T, Ts...>& callback) {
+		static arg_callback_t _make_lambda(const _values_callback_t<T, Ts...>& callback) {
 			if constexpr (mstd::is_same_function_v<_values_callback_t<T, Ts...>, arg_callback_t>) {
 				return callback;
 			}

--- a/include/margs/decoder.hpp
+++ b/include/margs/decoder.hpp
@@ -26,16 +26,16 @@ namespace margs {
 				if constexpr (std::is_integral_v<T>) {
 					// signed
 					if constexpr (std::is_signed_v<T>) {
-						return ston(scalar, rhs);
+						return mstd::strtonum(scalar, rhs);
 					}
 					// unsigned
 					else {
-						return stoun(scalar, rhs);
+						return mstd::strtounum(scalar, rhs);
 					}
 				}
 				// floating-point
 				else {
-					return stofp(scalar, rhs);
+					return mstd::strtofp(scalar, rhs);
 				}
 			}
 			// default


### PR DESCRIPTION
1. Heap allocation cannot be constexpr
> C:/Projects/Metronome/dependencies/margs/include\margs\arg_value.hpp:83:13: error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
   83 |                 constexpr arg_value(const std::string& value) : _type(_value_type::scalar),
   
2. Trying to declare a constexpr function that returns a type which cannot be used in a constant expression
> C:/Projects/Metronome/dependencies/margs/include\margs\basic_args_builder.hpp:77:35: error: constexpr function's return type 'arg_callback_t' (aka 'function<void (const arg_value &)>') is not a literal type
   77 |                 static constexpr arg_callback_t _make_lambda(const _flag_callback_t& callback) {